### PR TITLE
Disable wpautop

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 $asu_wp2020_includes = array(
 	'/theme-settings.php',                  // Initialize theme default settings.
 	'/setup.php',                           // Theme setup and custom theme supports.
+	'/wpautop.php',                         // Disable wpautop.
 	'/widgets.php',                         // Register widget area.
 	'/enqueue.php',                         // Enqueue scripts and styles.
 	'/template-tags.php',                   // Custom template tags for this theme.

--- a/inc/wpautop.php
+++ b/inc/wpautop.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Disable the WordPress wp_autop filter that automatically wraps lines in <p> tags.
+ *
+ * @package asu-web-standards-2020
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This line will prevent WordPress from automatically inserting HTML
+ * line breaks in your content. If you don't do this, some of the
+ * Bootstrap snippets that we are going to add will probably not
+ * display correctly.
+ *  See:  https://stackoverflow.com/questions/5940854/disable-automatic-formatting-inside-wordpress-shortcodes
+ */
+remove_filter( 'the_content', 'wpautop' );
+remove_filter( 'the_excerpt', 'wpautop' );


### PR DESCRIPTION
Disable the wpautop filter. This is a preliminary fix that will need to be revisited when we work on the Gutenberg editor. Gutenberg automatically disables wpauto when an HTML Block is being rendered, but wpautop may still be useful in other visual editing contexts.