### PR TITLE
Fix Navbar Closing Too Early

### DIFF
--- a/asu-navigation-menu.php
+++ b/asu-navigation-menu.php
@@ -54,17 +54,10 @@ foreach ($menu_items as $item) :
 						endforeach;
 						$column .= '</div>';
 
-						// output this collumn
+						// output this column
 						echo $column;
-						// we need to nullify $column in case this is the last column in this dropdown,
-						// and so it isn't rendered again below
-						$column = null;
 					endif;
 				endforeach;
-
-				// close out the basic one-column dropdown
-				$column .= '</div>';
-				echo $column;
 				?>
 			</div>
 		</div>


### PR DESCRIPTION
A few changes that clean up the code and prevent the main navigation menu from closing before it has rendered all menu items properly:

* Removed a closing `<div>` tag (line 66) that was the main culprit of the odd behavior we were seeing. This tag was attempting to close multi-level menu `<div>`s that were already being properly closed on line 55. The end result was that it closed the actual `navbar-nav` element after the first time we rendered a multi-level drop-down. This led to all subsequent top-level menu items existing outside the `navbar-nav`, where they picked up some flex-box styling from the parent `<div>` that spread them out across the screen.

* Removed the `echo` statement on line 67: we had already cleared out the `$column` variable at this point, meaning all we were actually doing was appending `</div>` to an empty string and then echoing that out (causing the problem listed above). With line 66 now gone, there was nothing to `echo` here.

* Removed  line 61,`$column=null`: With the echo statement from line 67 gone, we didn't necessarily need to worry about clearing this out, as `$column` is re-initialized on line 49 during every iteration of the child items loop. One could argue that it might be better to explicitly clear it out, anyway, but it's not strictly needed given the code we have right now.

* Fixed an instance of "column" being misspelled in a comment just because I happened to notice it.