### PR TITLE
Add Highlight Options to Hero Title

### DIFF
--- a/acf-json/group_5ef954da477f5.json
+++ b/acf-json/group_5ef954da477f5.json
@@ -67,6 +67,31 @@
             "maxlength": ""
         },
         {
+            "key": "field_5f5ac3e5eaa9e",
+            "label": "Hero Title Style",
+            "name": "hero_title_style",
+            "type": "radio",
+            "instructions": "Choose a Web 2.0 highlight style to be applied to the hero title text",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "gold": "Gold",
+                "black": "Black",
+                "none": "None"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "Gold",
+            "layout": "horizontal",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
             "key": "field_5ef956e49798b",
             "label": "Hero Text",
             "name": "hero_text",
@@ -166,5 +191,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1594687507
+    "modified": 1599784301
 }

--- a/acf-json/group_5ef954da477f5.json
+++ b/acf-json/group_5ef954da477f5.json
@@ -68,11 +68,11 @@
         },
         {
             "key": "field_5f5ac3e5eaa9e",
-            "label": "Hero Title Style",
-            "name": "hero_title_style",
+            "label": "Hero Highlight",
+            "name": "hero_highlight",
             "type": "radio",
             "instructions": "Choose a Web 2.0 highlight style to be applied to the hero title text",
-            "required": 1,
+            "required": 0,
             "conditional_logic": 0,
             "wrapper": {
                 "width": "",
@@ -80,8 +80,8 @@
                 "id": ""
             },
             "choices": {
-                "gold": "Gold",
-                "black": "Black",
+                "highlight-gold": "Gold",
+                "highlight-black": "Black",
                 "none": "None"
             },
             "allow_null": 0,
@@ -191,5 +191,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1599784301
+    "modified": 1600115228
 }

--- a/hero.php
+++ b/hero.php
@@ -14,19 +14,25 @@ defined('ABSPATH') || exit;
 $hero_asset_url = get_field('hero_asset_url');
 $hero_type = get_field('hero_type');
 $hero_title = get_field('hero_title');
+$hero_highlight = get_field('hero_highlight');
 $hero_text = get_field('hero_text');
 $hero_call_to_action_url = get_field('hero_call_to_action_url');
 $hero_call_to_action_text = get_field('hero_call_to_action_text');
 
+// if we don't have a highlight class from ACF, or it was set to "none"
+if( empty( $hero_highlight ) || "none" == $hero_highlight) {
+	$hero_highlight = "";
+}
+
 if (!empty($hero_asset_url)) :
 ?>
-<div class="uds-hero <?php echo $hero_type ?>" style="background-image: linear-gradient(180deg, #19191900 0%, #191919c9 100%), url('<?php echo wp_kses( $hero_asset_url, wp_kses_allowed_html( 'strip' ) ); ?>'); width: 100vw; margin-left: calc(50% - 50vw); max-width: 100vw !important;">
+<div class="uds-hero <?php echo $hero_type ?>" style="background-image: linear-gradient(180deg, #19191900 0%, #191919c9 100%), url('<?php echo wp_kses( $hero_asset_url, wp_kses_allowed_html( 'strip' ) ); ?>')">
 	<div class="container uds-hero-container">
 		<?php
 		if ( !empty( $hero_title ) ) :
 		?>
-		<h1 class="heading heading-one col-md-8">
-			<span class="highlight highlight-gold highlight-heading-one"><?php echo wp_kses( $hero_title, wp_kses_allowed_html( 'strip' ) ); ?></span>
+		<h1 class="col-md-8">
+			<span class="<?php echo $hero_highlight; ?>"><?php echo wp_kses( $hero_title, wp_kses_allowed_html( 'strip' ) ); ?></span>
 		</h1>
 		<?php
 		endif;


### PR DESCRIPTION
Add the ability for users to select a highlight style for the hero image title text:

* Added a new field to the existing ACF field group that allows the user to select "gold", "black", or "none" as a text highlight for hero images

* Added corresponding code in the `hero.php` template partial to implement the new option.

* Cleaned up the existing `hero.php` to remove some unnecessary CSS classes, and some inline CSS that would conflict with our current plans to limit hero images to a maximum of 1920px