### PR TITLE
Child theme compatibility - get_template_directory vs get_stylesheet_directory

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -55,7 +55,7 @@ if (!empty($cOptions['footer_row_actions'])) {
 								break;
 							}
 						}
-						echo wp_kses(sprintf($logo, get_stylesheet_directory_uri() . '/img/endorsed-logo/' . $filename, get_bloginfo('name') . ' Logo', home_url('/')), wp_kses_allowed_html('post'));
+						echo wp_kses(sprintf($logo, get_template_directory_uri() . '/img/endorsed-logo/' . $filename, get_bloginfo('name') . ' Logo', home_url('/')), wp_kses_allowed_html('post'));
 
 						// Else, check for Logo URL
 					} elseif (isset($cOptions) && array_key_exists('logo_url', $cOptions) && $cOptions['logo_url'] !== '') {
@@ -183,7 +183,7 @@ if (!empty($cOptions['footer_row_actions'])) {
 			<div class="row">
 				<div class="col">
 					<div class="d-flex footer-innovation-links">
-						<img src="<?php echo get_stylesheet_directory_uri(); ?>/img/innovation-lockup/on-gold/200420-GlobalFooter-No1InnovationLockup.png" alt="Number one in the U.S. for innovation. #1 ASU, #2 Stanford, #3 MIT. - U.S. News and World Report, 5 years, 2016-2020">
+						<img src="<?php echo get_template_directory_uri(); ?>/img/innovation-lockup/on-gold/200420-GlobalFooter-No1InnovationLockup.png" alt="Number one in the U.S. for innovation. #1 ASU, #2 Stanford, #3 MIT. - U.S. News and World Report, 5 years, 2016-2020">
 						<nav class="nav" aria-label="University Services">
 							<a class="nav-link" href="https://asu.edu/map/">Maps and Locations</a>
 							<a class="nav-link" href="https://asu.edu/asujobs">Jobs</a>

--- a/header.php
+++ b/header.php
@@ -139,8 +139,8 @@ if (!empty($cOptions['hotjar_site_id'])) {
 							<nav class="navbar navbar-expand-xl" aria-label="Main">
 
 								<a class="navbar-brand" href="#">
-									<img class="vert" src="<?php echo get_stylesheet_directory_uri(); ?>/img/logo/asu_university_vert_maroongold.png" alt="Arizona State University" />
-									<img class="horiz" src="<?php echo get_stylesheet_directory_uri(); ?>/img/logo/asu_university_horiz_maroongold.png" alt="Arizona State University" />
+									<img class="vert" src="<?php echo get_template_directory_uri(); ?>/img/logo/asu_university_vert_maroongold.png" alt="Arizona State University" />
+									<img class="horiz" src="<?php echo get_template_directory_uri(); ?>/img/logo/asu_university_horiz_maroongold.png" alt="Arizona State University" />
 								</a>
 
 								<button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#menubar" aria-controls="menubar" aria-expanded="false" aria-label="Toggle navigation">

--- a/header.php
+++ b/header.php
@@ -16,6 +16,7 @@ $asu_hub_analytics     = 'disabled';
 $site_gtm_container_id = '';
 $site_ga_tracking_id   = '';
 $hotjar_site_id        = '';
+$nav_menu_enabled	   = '';
 
 // Check if we have Customizer options set
 if (is_array(get_option('asu_wp2020_theme_options'))) {

--- a/inc/advanced-custom-fields.php
+++ b/inc/advanced-custom-fields.php
@@ -9,8 +9,8 @@
 defined( 'ABSPATH' ) || exit;
 
 // Define path and URL to the integrated ACF plugin in the theme.
-define( 'ACF_PLUGIN_PATH', get_stylesheet_directory() . '/inc/acf/' );
-define( 'ACF_PLUGIN_URL', get_stylesheet_directory_uri() . '/inc/acf/' );
+define( 'ACF_PLUGIN_PATH', get_template_directory() . '/inc/acf/' );
+define( 'ACF_PLUGIN_URL', get_template_directory_uri() . '/inc/acf/' );
 
 // Include the ACF plugin.
 include_once( ACF_PLUGIN_PATH . 'acf.php' );


### PR DESCRIPTION
The use of `get_stylesheet` functions in various parts of the parent theme will fail when in the presence of a child theme. These are a set of corrections that should force the parent theme to look within ONLY the parent theme for the various called resources. 